### PR TITLE
Support for Calendar dates and times

### DIFF
--- a/lib/useful.ex
+++ b/lib/useful.ex
@@ -17,6 +17,11 @@ defmodule Useful do
       %{name: "alex", data: %{age: 17}}
 
   """
+  def atomize_map_keys(%Date{} = value), do: value
+  def atomize_map_keys(%Time{} = value), do: value
+  def atomize_map_keys(%DateTime{} = value), do: value
+  def atomize_map_keys(%NaiveDateTime{} = value), do: value
+
   def atomize_map_keys(map) when is_map(map) do
     for {key, val} <- map, into: %{} do
       cond do
@@ -105,6 +110,7 @@ defmodule Useful do
     # Enum.each(keys, )
     try do
       dbg(map)
+
       case get_in(map, keys) do
         nil -> default
         result -> result

--- a/test/useful_test.exs
+++ b/test/useful_test.exs
@@ -16,6 +16,17 @@ defmodule UsefulTest do
     assert expected == %{id: 1, name: "alex", nested: %{age: 17, height: 185}}
   end
 
+  test "atomize_map_keys/1 handles Date, Time, DateTime and NaiveDateTime" do
+    map = %{
+      date: ~D[2023-03-30],
+      time: ~T[12:00:00],
+      naive_date_time: ~N[2023-03-30 12:00:00],
+      date_time: ~U[2023-03-30 12:00:00Z]
+    }
+
+    assert Useful.atomize_map_keys(map) == map
+  end
+
   defp write_files_in_dir(dir) do
     file_name = "test.txt"
     file_path = Path.join([dir, file_name]) |> Path.expand()


### PR DESCRIPTION
Hi, this PR adds support for Calendar dates and times,
to avoid this kind of error:

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for ~N[2023-03-30 12:00:00] of type NaiveDateTime (a struct)
```