### PR TITLE
Add support for %Plug.Upload{}

### DIFF
--- a/lib/useful.ex
+++ b/lib/useful.ex
@@ -21,6 +21,7 @@ defmodule Useful do
   def atomize_map_keys(%Time{} = value), do: value
   def atomize_map_keys(%DateTime{} = value), do: value
   def atomize_map_keys(%NaiveDateTime{} = value), do: value
+  def atomize_map_keys(%Plug.Upload{} = value), do: value
 
   # handle lists in maps: github.com/dwyl/useful/issues/46
   def atomize_map_keys(items) when is_list(items) do

--- a/test/useful_test.exs
+++ b/test/useful_test.exs
@@ -27,6 +27,18 @@ defmodule UsefulTest do
     assert Useful.atomize_map_keys(map) == map
   end
 
+  test "atomize_map_keys/1 handles Plug.Upload" do
+    map = %{
+      image: %Plug.Upload{
+        path: "path/to/file",
+        filename: "file_name.ext",
+        content_type: "application/pdf"
+      }
+    }
+
+    assert Useful.atomize_map_keys(map) == map
+  end
+
   test "atomize_map_keys/1 converts map containing list of maps" do
     map = %{
       "items" => [


### PR DESCRIPTION
This PR adds support for Plug.Upload to avoid this kind of error:

`(Protocol.UndefinedError) protocol Enumerable not implemented for %Plug.Upload{}`