### PR TITLE
PR: Bump version to 1.12.0 to release support for `%Plug.Upload{}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Install by adding `useful` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:useful, "~> 1.11.1"}
+    {:useful, "~> 1.12.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Useful.MixProject do
     [
       app: :useful,
       description: "A collection of useful functions",
-      version: "1.11.1",
+      version: "1.12.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
bump version to 1.12.0 to release support for `%Plug.Upload{}` in `atomize_map_keys/1` thanks to @icr4 #49